### PR TITLE
Add secret page support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,23 @@ sudo: required
 dist: trusty
 osx_image: xcode8
 language: cpp
-os: 
- - linux
- - osx
-compiler: 
- - clang
+os:
+- linux
+- osx
+compiler:
+- clang
 before_install:
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo easy_install pip; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo pip install --upgrade pyyaml xlsxwriter; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo /usr/bin/env python -m pip install --upgrade pip; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then /usr/bin/env python -m pip install --user --upgrade pyyaml xlsxwriter; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y libc6-dev libc6-dev-i386 g++-multilib; fi
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo easy_install pip; fi
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo pip install --upgrade pyyaml xlsxwriter;
+  fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo /usr/bin/env python -m pip install
+  --upgrade pip; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then /usr/bin/env python -m pip install --user
+  --upgrade pyyaml xlsxwriter; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y libc6-dev libc6-dev-i386
+  g++-multilib; fi
 script:
-  - ./build.sh
+- ./build.sh
+notifications:
+  slack:
+    secure: P55a2c+EwQDUDV4mhcw80fLqSCSldkZjOEi1EQCVdpGkVzGXV4fUVKQquMqw62ctNvCLrPeOpvAHuQagR2e5L2FOifDMvtABaJyitHnaN03Bu/TKud1fRls7WhjsTPOd1SboG1XN7VnvhcJKIrQh4Jh/QSc+3DVE0a0GY3F5veDSsvdJJCHQuvuErSgkXw0P0BbyUuw6pP5ZUY2gWKRU9U/RZXx++W9xCMEL1fh0wD27pwMMILQhcmJrLAmgpkg/pSNU4LPMREnFwgVQsxLeKGSt/Ri0aXQUx1UVwly9ZGLskSZMZvsvXRWCd9GCOxTAEoDWlx/DroPQniPHTQ4/g19uK9fjp4hLKWxVdG6S3jdOgtwKvbCwmuS0zVCFpl033pn8z+9S4+BESdCPD1KxakvZn1yFh0k2qx9R1L+0D9mn2OCoJKsYoiF0dLzqqX//AUZHidKd0i4GCZSCaTbXsZU2Ad5dk2wXDMs0gLTkk31wrH3WKRJjiADxhVbMJKpA/EUh1UvIO/t3PMSxAnVmke+AeC7rc0Ja/czaFq1jnELVTqnHYqwUqjznmZzlRZTPVfnovZApZyYscCFVqDaUGbart0C8vJTtuy3LZrqFxgke/+SwyFaIG+PofHcwC1+YpbSNQzqX9tK6t8Y5d1l6LKCIIw8um+wUAd9+v8cLMVk=

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,12 @@ endif()
 set(main_dir processed-challenges) # directory which contains all cb subdirs
 
 file(GLOB challenge_binaries ${main_dir}/*) # list of all files(+paths) in maindir - all dirs should be cbs
+
+# Build libcgc
 add_subdirectory(include)
+
+# Build tiny-AES128-C
+add_subdirectory(include/tiny-AES128-C)
 
 function(build path target)
     message("Building ${target}")

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,5 +1,5 @@
 enable_language(ASM)
-add_library(libcgc libcgc.c maths.S)
+add_library(libcgc libcgc.c maths.S ansi_x931_aes128.c)
 
 if(APPLE)
     set(flags "-DAPPLE")

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -6,7 +6,7 @@ if(APPLE)
 endif()
 
 if(LINUX)
-    set(flags "-fno-builtin   -DLINUX")
+    set(flags "-fno-builtin -DLINUX")
 endif()
 
 if(WIN)
@@ -14,5 +14,5 @@ if(WIN)
 endif()
 
 set_target_properties(libcgc PROPERTIES COMPILE_FLAGS "-m32 ${flags}")
-
-target_include_directories(libcgc PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(libcgc PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/tiny-AES128-C)
+target_link_libraries(libcgc LINK_PUBLIC tiny-AES128-C)

--- a/include/ansi_x931_aes128.c
+++ b/include/ansi_x931_aes128.c
@@ -1,1 +1,93 @@
 #include "ansi_x931_aes128.h"
+#include "tiny-AES128-C/aes.h"
+
+#include <string.h>
+#include <stdlib.h>
+
+// TODO: CROSS PLATFORM?
+
+// Some helpers for the prng
+void __cgc_gen_block(cgc_prng*);
+void __cgc_xor(const uint8_t*, const uint8_t*, uint8_t*);
+
+/**
+ * Initializes a PRNG from a given seed
+ * @param  seed Initial state of the PRNG
+ * @return      Generated PRNG
+ */
+cgc_prng cgc_init_prng(const uint8_t *seed) {
+    cgc_prng prng;
+    memcpy(&prng.state, seed, sizeof(cgc_aes_state));
+    for (int i = 0; i < BLOCK_SIZE; ++i) {
+        prng.random_data[i] = '\x00';
+        prng.intermediate[i] = '\x00';
+    }
+
+    // Force a new block to be generated immediately
+    prng.random_idx = BLOCK_SIZE;
+
+    return prng;
+}
+
+/**
+ * Generates a chosen amount of random data and saves it to a buffer
+ * @param prng Initial PRNG state
+ * @param len  Amount of data to generate
+ * @param buf  Buffer to store the data in
+ */
+void cgc_aes_get_bytes(cgc_prng *prng, uint32_t len, uint8_t *buf) {
+    uint32_t buf_idx = 0;
+    while (buf_idx < len) {
+        // Generate another block of random data if needed
+        if (prng->random_idx >= BLOCK_SIZE) {
+            __cgc_gen_block(prng);
+        }
+
+        // Copy over data until we run out of data or the end of the buffer is reached
+        while (prng->random_idx < BLOCK_SIZE && buf_idx < len) {
+            buf[buf_idx++] = prng->random_data[prng->random_idx++];
+        }
+    }
+}
+
+
+/**
+ * XORs the first BLOCK_SIZE bytes of two buffers and saves the result in an output buffer
+ * @param a   First input buffer
+ * @param b   Second input buffer
+ * @param buf Output buffer
+ */
+void __cgc_xor(const uint8_t *a, const uint8_t *b, uint8_t *buf) {
+    for (int i = 0; i < BLOCK_SIZE; ++i) {
+        buf[i] = a[i] ^ b[i];
+    }
+}
+
+/**
+ * Generates a new block of random data and stores it in the prng
+ * @param prng PRNG to generate the new data for
+ */
+void __cgc_gen_block(cgc_prng *prng) {
+    // Encrypt counter value, giving the intermediate
+    AES128_ECB_encrypt(prng->state.datetime, prng->state.key, prng->intermediate);
+
+    // XOR intermediate and aes vector, encrypt the result to get the random data
+    uint8_t tmp[16];
+    __cgc_xor(prng->intermediate, prng->state.vec, tmp);
+    AES128_ECB_encrypt(tmp, prng->state.key, prng->random_data);
+
+    // Reset random data index
+    prng->random_idx = 0;
+
+    // XOR random data with intermediate, encrypt the result to get the new vector
+    __cgc_xor(prng->intermediate, prng->random_data, tmp);
+    AES128_ECB_encrypt(tmp, prng->state.key, prng->state.vec);
+
+    // Update the datetime counter
+    uint8_t i = BLOCK_SIZE - 1;
+    while (i >= 0) {
+        ++prng->state.datetime[i];
+        if (prng->state.datetime[i] != 0) break;
+        i -= 1;
+    }
+}

--- a/include/ansi_x931_aes128.c
+++ b/include/ansi_x931_aes128.c
@@ -18,10 +18,8 @@ void __cgc_xor(const uint8_t*, const uint8_t*, uint8_t*);
 cgc_prng cgc_init_prng(const uint8_t *seed) {
     cgc_prng prng;
     memcpy(&prng.state, seed, sizeof(cgc_aes_state));
-    for (int i = 0; i < BLOCK_SIZE; ++i) {
-        prng.random_data[i] = '\x00';
-        prng.intermediate[i] = '\x00';
-    }
+    memset(prng.random_data, 0, BLOCK_SIZE);
+    memset(prng.intermediate, 0, BLOCK_SIZE);
 
     // Force a new block to be generated immediately
     prng.random_idx = BLOCK_SIZE;

--- a/include/ansi_x931_aes128.c
+++ b/include/ansi_x931_aes128.c
@@ -15,16 +15,12 @@ void cgc_xor(const uint8_t*, const uint8_t*, uint8_t*);
  * @param  seed Initial state of the PRNG
  * @return      Generated PRNG
  */
-cgc_prng cgc_init_prng(const uint8_t *seed) {
-    cgc_prng prng;
-    memcpy(&prng.state, seed, sizeof(cgc_aes_state));
-    memset(prng.random_data, 0, BLOCK_SIZE);
-    memset(prng.intermediate, 0, BLOCK_SIZE);
+void cgc_init_prng(cgc_prng *prng, const cgc_aes_state *seed) {
+    memset(prng, 0, sizeof(cgc_prng));
+    memcpy(&prng->state, seed, sizeof(cgc_aes_state));
 
     // Force a new block to be generated immediately
-    prng.random_idx = BLOCK_SIZE;
-
-    return prng;
+    prng->random_idx = BLOCK_SIZE;
 }
 
 /**
@@ -70,7 +66,7 @@ void cgc_gen_block(cgc_prng *prng) {
     AES128_ECB_encrypt(prng->state.datetime, prng->state.key, prng->intermediate);
 
     // XOR intermediate and aes vector, encrypt the result to get the random data
-    uint8_t tmp[16];
+    uint8_t tmp[BLOCK_SIZE];
     cgc_xor(prng->intermediate, prng->state.vec, tmp);
     AES128_ECB_encrypt(tmp, prng->state.key, prng->random_data);
 

--- a/include/ansi_x931_aes128.c
+++ b/include/ansi_x931_aes128.c
@@ -1,0 +1,1 @@
+#include "ansi_x931_aes128.h"

--- a/include/ansi_x931_aes128.h
+++ b/include/ansi_x931_aes128.h
@@ -8,12 +8,13 @@
  * This is the AES related info for a prng
  * A prng seed contains all of this data
  */
-#pragma pack(1)
+#pragma pack(push, 1)
 typedef struct cgc_aes_state {
     uint8_t vec[BLOCK_SIZE];
     uint8_t key[BLOCK_SIZE];
     uint8_t datetime[BLOCK_SIZE];
 } cgc_aes_state;
+#pragma pack(pop)
 
 typedef struct cgc_prng {
     cgc_aes_state state;

--- a/include/ansi_x931_aes128.h
+++ b/include/ansi_x931_aes128.h
@@ -1,0 +1,4 @@
+#ifndef _ANSI_X931_AES128_H_
+#define _ANSI_X931_AES128_H_
+
+#endif

--- a/include/ansi_x931_aes128.h
+++ b/include/ansi_x931_aes128.h
@@ -1,4 +1,26 @@
 #ifndef _ANSI_X931_AES128_H_
 #define _ANSI_X931_AES128_H_
 
+#define BLOCK_SIZE 16
+#include <stdint.h>
+
+/**
+ * This is the AES related info for a prng
+ * A prng seed contains all of this data
+ */
+typedef struct cgc_aes_state {
+    uint8_t vec[BLOCK_SIZE];
+    uint8_t key[BLOCK_SIZE];
+    uint8_t datetime[BLOCK_SIZE];
+} cgc_aes_state;
+
+typedef struct cgc_prng {
+    cgc_aes_state state;
+    uint8_t intermediate[BLOCK_SIZE];
+    uint8_t random_data[BLOCK_SIZE];
+    uint8_t random_idx;
+} cgc_prng;
+
+cgc_prng cgc_init_prng(const uint8_t*);
+void cgc_aes_get_bytes(cgc_prng*, uint32_t, uint8_t*);
 #endif

--- a/include/ansi_x931_aes128.h
+++ b/include/ansi_x931_aes128.h
@@ -8,6 +8,7 @@
  * This is the AES related info for a prng
  * A prng seed contains all of this data
  */
+#pragma pack(1)
 typedef struct cgc_aes_state {
     uint8_t vec[BLOCK_SIZE];
     uint8_t key[BLOCK_SIZE];
@@ -21,6 +22,6 @@ typedef struct cgc_prng {
     uint8_t random_idx;
 } cgc_prng;
 
-cgc_prng cgc_init_prng(const uint8_t*);
+void cgc_init_prng(cgc_prng*, const cgc_aes_state*);
 void cgc_aes_get_bytes(cgc_prng*, uint32_t, uint8_t*);
 #endif

--- a/include/libcgc.c
+++ b/include/libcgc.c
@@ -494,7 +494,7 @@ void try_init_prng() {
 
     // This will be hex encoded
     const char *prng_seed_hex = getenv("seed");
-    if (prng_seed_hex == NULL) {
+    if (prng_seed_hex == NULL || strlen(prng_seed_hex) != (BLOCK_SIZE * 3) * 2) {
         // TODO: Actually make this random
         prng_seed_hex = "736565647365656473656564736565643031323334353637383961626364656600000000000000000000000000000000";
     }
@@ -509,7 +509,8 @@ void try_init_prng() {
 
     // Create the prng
     cgc_internal_prng = (cgc_prng *) malloc(sizeof(cgc_prng));
-    *cgc_internal_prng = cgc_init_prng(prng_seed);
+    cgc_aes_state *seed = (cgc_aes_state *) prng_seed;
+    cgc_init_prng(cgc_internal_prng, seed);
 }
 
 int cgc_random(void *buf, cgc_size_t count, cgc_size_t *rnd_bytes) {

--- a/include/libcgc.c
+++ b/include/libcgc.c
@@ -484,13 +484,13 @@ int deallocate(void *addr, cgc_size_t length) {
 }
 
 
-cgc_prng *prng = NULL;
+cgc_prng *cgc_internal_prng = NULL;
 /**
  * Initializes the prng for use with cgc_random and the secret page
  */
 void try_init_prng() {
     // Don't reinitialize
-    if (prng != NULL) return;
+    if (cgc_internal_prng != NULL) return;
 
     // This will be hex encoded
     const char *prng_seed_hex = getenv("seed");
@@ -508,8 +508,8 @@ void try_init_prng() {
     }
 
     // Create the prng
-    prng = (cgc_prng *) malloc(sizeof(cgc_prng));
-    *prng = cgc_init_prng(prng_seed);
+    cgc_internal_prng = (cgc_prng *) malloc(sizeof(cgc_prng));
+    *cgc_internal_prng = cgc_init_prng(prng_seed);
 }
 
 int cgc_random(void *buf, cgc_size_t count, cgc_size_t *rnd_bytes) {
@@ -522,7 +522,7 @@ int cgc_random(void *buf, cgc_size_t count, cgc_size_t *rnd_bytes) {
   } else {
     // Get random bytes from the prng
     try_init_prng();
-    cgc_aes_get_bytes(prng, count, buf);
+    cgc_aes_get_bytes(cgc_internal_prng, count, buf);
     return update_byte_count(rnd_bytes, count);
   }
 }
@@ -542,7 +542,7 @@ void *cgc_initialize_secret_page(void) {
 
   // Fill the magic page with bytes from the prng
   try_init_prng();
-  cgc_aes_get_bytes(prng, MAGIC_PAGE_SIZE, mmap_addr);
+  cgc_aes_get_bytes(cgc_internal_prng, MAGIC_PAGE_SIZE, mmap_addr);
 
   return mmap_addr;
 }

--- a/include/libcgc.c
+++ b/include/libcgc.c
@@ -518,12 +518,21 @@ void *cgc_initialize_secret_page(void) {
     err(1, "[!] Failed to map the secret page");
   }
 
-  const uint8_t *prng_seed = (uint8_t *) getenv("seed");
-  if (prng_seed == NULL) {
-      printf("Environment variable 'seed' not found, generating random seed\n");
+  // This will be hex encoded
+  const char *prng_seed_hex = getenv("seed");
+  if (prng_seed_hex == NULL) {
+    //   printf("Environment variable 'seed' not found, generating random seed\n");
 
       // TODO: Actually make this random
-      prng_seed = (uint8_t *) "seedseedseedseed0123456789abcdef\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+      prng_seed_hex = "736565647365656473656564736565643031323334353637383961626364656600000000000000000000000000000000";
+  }
+
+  // Convert the hex encoded seed to a normal string
+  const char *pos = prng_seed_hex;
+  uint8_t *prng_seed = calloc(0, (BLOCK_SIZE * 3) * sizeof(uint8_t));
+  for(int i = 0; i < BLOCK_SIZE * 3; ++i) {
+      sscanf(pos, "%2hhx", &prng_seed[i]);
+      pos += 2;
   }
 
   // Fill the magic page

--- a/include/libcgc.c
+++ b/include/libcgc.c
@@ -521,15 +521,13 @@ void *cgc_initialize_secret_page(void) {
   // This will be hex encoded
   const char *prng_seed_hex = getenv("seed");
   if (prng_seed_hex == NULL) {
-    //   printf("Environment variable 'seed' not found, generating random seed\n");
-
       // TODO: Actually make this random
       prng_seed_hex = "736565647365656473656564736565643031323334353637383961626364656600000000000000000000000000000000";
   }
 
   // Convert the hex encoded seed to a normal string
   const char *pos = prng_seed_hex;
-  uint8_t *prng_seed = calloc(0, (BLOCK_SIZE * 3) * sizeof(uint8_t));
+  uint8_t prng_seed[BLOCK_SIZE * 3];
   for(int i = 0; i < BLOCK_SIZE * 3; ++i) {
       sscanf(pos, "%2hhx", &prng_seed[i]);
       pos += 2;

--- a/include/tiny-AES128-C/CMakeLists.txt
+++ b/include/tiny-AES128-C/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(tiny-AES128-C aes.c)
+set_target_properties(tiny-AES128-C PROPERTIES COMPILE_FLAGS "-m32")
+target_include_directories(tiny-AES128-C PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/include/tiny-AES128-C/aes.c
+++ b/include/tiny-AES128-C/aes.c
@@ -1,0 +1,581 @@
+/*
+
+This is an implementation of the AES128 algorithm, specifically ECB and CBC mode.
+
+The implementation is verified against the test vectors in:
+  National Institute of Standards and Technology Special Publication 800-38A 2001 ED
+
+ECB-AES128
+----------
+
+  plain-text:
+    6bc1bee22e409f96e93d7e117393172a
+    ae2d8a571e03ac9c9eb76fac45af8e51
+    30c81c46a35ce411e5fbc1191a0a52ef
+    f69f2445df4f9b17ad2b417be66c3710
+
+  key:
+    2b7e151628aed2a6abf7158809cf4f3c
+
+  resulting cipher
+    3ad77bb40d7a3660a89ecaf32466ef97
+    f5d3d58503b9699de785895a96fdbaaf
+    43b1cd7f598ece23881b00e3ed030688
+    7b0c785e27e8ad3f8223207104725dd4
+
+
+NOTE:   String length must be evenly divisible by 16byte (str_len % 16 == 0)
+        You should pad the end of the string with zeros if this is not the case.
+
+*/
+
+
+/*****************************************************************************/
+/* Includes:                                                                 */
+/*****************************************************************************/
+#include <stdint.h>
+#include <string.h> // CBC mode, for memset
+#include "aes.h"
+
+
+/*****************************************************************************/
+/* Defines:                                                                  */
+/*****************************************************************************/
+// The number of columns comprising a state in AES. This is a constant in AES. Value=4
+#define Nb 4
+// The number of 32 bit words in a key.
+#define Nk 4
+// Key length in bytes [128 bit]
+#define KEYLEN 16
+// The number of rounds in AES Cipher.
+#define Nr 10
+
+// jcallan@github points out that declaring Multiply as a function
+// reduces code size considerably with the Keil ARM compiler.
+// See this link for more information: https://github.com/kokke/tiny-AES128-C/pull/3
+#ifndef MULTIPLY_AS_A_FUNCTION
+  #define MULTIPLY_AS_A_FUNCTION 0
+#endif
+
+
+/*****************************************************************************/
+/* Private variables:                                                        */
+/*****************************************************************************/
+// state - array holding the intermediate results during decryption.
+typedef uint8_t state_t[4][4];
+static state_t* state;
+
+// The array that stores the round keys.
+static uint8_t RoundKey[176];
+
+// The Key input to the AES Program
+static const uint8_t* Key;
+
+#if defined(CBC) && CBC
+  // Initial Vector used only for CBC mode
+  static uint8_t* Iv;
+#endif
+
+// The lookup-tables are marked const so they can be placed in read-only storage instead of RAM
+// The numbers below can be computed dynamically trading ROM for RAM -
+// This can be useful in (embedded) bootloader applications, where ROM is often limited.
+static const uint8_t sbox[256] =   {
+  //0     1    2      3     4    5     6     7      8    9     A      B    C     D     E     F
+  0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5, 0x30, 0x01, 0x67, 0x2b, 0xfe, 0xd7, 0xab, 0x76,
+  0xca, 0x82, 0xc9, 0x7d, 0xfa, 0x59, 0x47, 0xf0, 0xad, 0xd4, 0xa2, 0xaf, 0x9c, 0xa4, 0x72, 0xc0,
+  0xb7, 0xfd, 0x93, 0x26, 0x36, 0x3f, 0xf7, 0xcc, 0x34, 0xa5, 0xe5, 0xf1, 0x71, 0xd8, 0x31, 0x15,
+  0x04, 0xc7, 0x23, 0xc3, 0x18, 0x96, 0x05, 0x9a, 0x07, 0x12, 0x80, 0xe2, 0xeb, 0x27, 0xb2, 0x75,
+  0x09, 0x83, 0x2c, 0x1a, 0x1b, 0x6e, 0x5a, 0xa0, 0x52, 0x3b, 0xd6, 0xb3, 0x29, 0xe3, 0x2f, 0x84,
+  0x53, 0xd1, 0x00, 0xed, 0x20, 0xfc, 0xb1, 0x5b, 0x6a, 0xcb, 0xbe, 0x39, 0x4a, 0x4c, 0x58, 0xcf,
+  0xd0, 0xef, 0xaa, 0xfb, 0x43, 0x4d, 0x33, 0x85, 0x45, 0xf9, 0x02, 0x7f, 0x50, 0x3c, 0x9f, 0xa8,
+  0x51, 0xa3, 0x40, 0x8f, 0x92, 0x9d, 0x38, 0xf5, 0xbc, 0xb6, 0xda, 0x21, 0x10, 0xff, 0xf3, 0xd2,
+  0xcd, 0x0c, 0x13, 0xec, 0x5f, 0x97, 0x44, 0x17, 0xc4, 0xa7, 0x7e, 0x3d, 0x64, 0x5d, 0x19, 0x73,
+  0x60, 0x81, 0x4f, 0xdc, 0x22, 0x2a, 0x90, 0x88, 0x46, 0xee, 0xb8, 0x14, 0xde, 0x5e, 0x0b, 0xdb,
+  0xe0, 0x32, 0x3a, 0x0a, 0x49, 0x06, 0x24, 0x5c, 0xc2, 0xd3, 0xac, 0x62, 0x91, 0x95, 0xe4, 0x79,
+  0xe7, 0xc8, 0x37, 0x6d, 0x8d, 0xd5, 0x4e, 0xa9, 0x6c, 0x56, 0xf4, 0xea, 0x65, 0x7a, 0xae, 0x08,
+  0xba, 0x78, 0x25, 0x2e, 0x1c, 0xa6, 0xb4, 0xc6, 0xe8, 0xdd, 0x74, 0x1f, 0x4b, 0xbd, 0x8b, 0x8a,
+  0x70, 0x3e, 0xb5, 0x66, 0x48, 0x03, 0xf6, 0x0e, 0x61, 0x35, 0x57, 0xb9, 0x86, 0xc1, 0x1d, 0x9e,
+  0xe1, 0xf8, 0x98, 0x11, 0x69, 0xd9, 0x8e, 0x94, 0x9b, 0x1e, 0x87, 0xe9, 0xce, 0x55, 0x28, 0xdf,
+  0x8c, 0xa1, 0x89, 0x0d, 0xbf, 0xe6, 0x42, 0x68, 0x41, 0x99, 0x2d, 0x0f, 0xb0, 0x54, 0xbb, 0x16 };
+
+static const uint8_t rsbox[256] =
+{ 0x52, 0x09, 0x6a, 0xd5, 0x30, 0x36, 0xa5, 0x38, 0xbf, 0x40, 0xa3, 0x9e, 0x81, 0xf3, 0xd7, 0xfb,
+  0x7c, 0xe3, 0x39, 0x82, 0x9b, 0x2f, 0xff, 0x87, 0x34, 0x8e, 0x43, 0x44, 0xc4, 0xde, 0xe9, 0xcb,
+  0x54, 0x7b, 0x94, 0x32, 0xa6, 0xc2, 0x23, 0x3d, 0xee, 0x4c, 0x95, 0x0b, 0x42, 0xfa, 0xc3, 0x4e,
+  0x08, 0x2e, 0xa1, 0x66, 0x28, 0xd9, 0x24, 0xb2, 0x76, 0x5b, 0xa2, 0x49, 0x6d, 0x8b, 0xd1, 0x25,
+  0x72, 0xf8, 0xf6, 0x64, 0x86, 0x68, 0x98, 0x16, 0xd4, 0xa4, 0x5c, 0xcc, 0x5d, 0x65, 0xb6, 0x92,
+  0x6c, 0x70, 0x48, 0x50, 0xfd, 0xed, 0xb9, 0xda, 0x5e, 0x15, 0x46, 0x57, 0xa7, 0x8d, 0x9d, 0x84,
+  0x90, 0xd8, 0xab, 0x00, 0x8c, 0xbc, 0xd3, 0x0a, 0xf7, 0xe4, 0x58, 0x05, 0xb8, 0xb3, 0x45, 0x06,
+  0xd0, 0x2c, 0x1e, 0x8f, 0xca, 0x3f, 0x0f, 0x02, 0xc1, 0xaf, 0xbd, 0x03, 0x01, 0x13, 0x8a, 0x6b,
+  0x3a, 0x91, 0x11, 0x41, 0x4f, 0x67, 0xdc, 0xea, 0x97, 0xf2, 0xcf, 0xce, 0xf0, 0xb4, 0xe6, 0x73,
+  0x96, 0xac, 0x74, 0x22, 0xe7, 0xad, 0x35, 0x85, 0xe2, 0xf9, 0x37, 0xe8, 0x1c, 0x75, 0xdf, 0x6e,
+  0x47, 0xf1, 0x1a, 0x71, 0x1d, 0x29, 0xc5, 0x89, 0x6f, 0xb7, 0x62, 0x0e, 0xaa, 0x18, 0xbe, 0x1b,
+  0xfc, 0x56, 0x3e, 0x4b, 0xc6, 0xd2, 0x79, 0x20, 0x9a, 0xdb, 0xc0, 0xfe, 0x78, 0xcd, 0x5a, 0xf4,
+  0x1f, 0xdd, 0xa8, 0x33, 0x88, 0x07, 0xc7, 0x31, 0xb1, 0x12, 0x10, 0x59, 0x27, 0x80, 0xec, 0x5f,
+  0x60, 0x51, 0x7f, 0xa9, 0x19, 0xb5, 0x4a, 0x0d, 0x2d, 0xe5, 0x7a, 0x9f, 0x93, 0xc9, 0x9c, 0xef,
+  0xa0, 0xe0, 0x3b, 0x4d, 0xae, 0x2a, 0xf5, 0xb0, 0xc8, 0xeb, 0xbb, 0x3c, 0x83, 0x53, 0x99, 0x61,
+  0x17, 0x2b, 0x04, 0x7e, 0xba, 0x77, 0xd6, 0x26, 0xe1, 0x69, 0x14, 0x63, 0x55, 0x21, 0x0c, 0x7d };
+
+
+// The round constant word array, Rcon[i], contains the values given by
+// x to th e power (i-1) being powers of x (x is denoted as {02}) in the field GF(2^8)
+// Note that i starts at 1, not 0).
+static const uint8_t Rcon[255] = {
+  0x8d, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36, 0x6c, 0xd8, 0xab, 0x4d, 0x9a,
+  0x2f, 0x5e, 0xbc, 0x63, 0xc6, 0x97, 0x35, 0x6a, 0xd4, 0xb3, 0x7d, 0xfa, 0xef, 0xc5, 0x91, 0x39,
+  0x72, 0xe4, 0xd3, 0xbd, 0x61, 0xc2, 0x9f, 0x25, 0x4a, 0x94, 0x33, 0x66, 0xcc, 0x83, 0x1d, 0x3a,
+  0x74, 0xe8, 0xcb, 0x8d, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36, 0x6c, 0xd8,
+  0xab, 0x4d, 0x9a, 0x2f, 0x5e, 0xbc, 0x63, 0xc6, 0x97, 0x35, 0x6a, 0xd4, 0xb3, 0x7d, 0xfa, 0xef,
+  0xc5, 0x91, 0x39, 0x72, 0xe4, 0xd3, 0xbd, 0x61, 0xc2, 0x9f, 0x25, 0x4a, 0x94, 0x33, 0x66, 0xcc,
+  0x83, 0x1d, 0x3a, 0x74, 0xe8, 0xcb, 0x8d, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b,
+  0x36, 0x6c, 0xd8, 0xab, 0x4d, 0x9a, 0x2f, 0x5e, 0xbc, 0x63, 0xc6, 0x97, 0x35, 0x6a, 0xd4, 0xb3,
+  0x7d, 0xfa, 0xef, 0xc5, 0x91, 0x39, 0x72, 0xe4, 0xd3, 0xbd, 0x61, 0xc2, 0x9f, 0x25, 0x4a, 0x94,
+  0x33, 0x66, 0xcc, 0x83, 0x1d, 0x3a, 0x74, 0xe8, 0xcb, 0x8d, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20,
+  0x40, 0x80, 0x1b, 0x36, 0x6c, 0xd8, 0xab, 0x4d, 0x9a, 0x2f, 0x5e, 0xbc, 0x63, 0xc6, 0x97, 0x35,
+  0x6a, 0xd4, 0xb3, 0x7d, 0xfa, 0xef, 0xc5, 0x91, 0x39, 0x72, 0xe4, 0xd3, 0xbd, 0x61, 0xc2, 0x9f,
+  0x25, 0x4a, 0x94, 0x33, 0x66, 0xcc, 0x83, 0x1d, 0x3a, 0x74, 0xe8, 0xcb, 0x8d, 0x01, 0x02, 0x04,
+  0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36, 0x6c, 0xd8, 0xab, 0x4d, 0x9a, 0x2f, 0x5e, 0xbc, 0x63,
+  0xc6, 0x97, 0x35, 0x6a, 0xd4, 0xb3, 0x7d, 0xfa, 0xef, 0xc5, 0x91, 0x39, 0x72, 0xe4, 0xd3, 0xbd,
+  0x61, 0xc2, 0x9f, 0x25, 0x4a, 0x94, 0x33, 0x66, 0xcc, 0x83, 0x1d, 0x3a, 0x74, 0xe8, 0xcb  };
+
+
+/*****************************************************************************/
+/* Private functions:                                                        */
+/*****************************************************************************/
+static uint8_t getSBoxValue(uint8_t num)
+{
+  return sbox[num];
+}
+
+static uint8_t getSBoxInvert(uint8_t num)
+{
+  return rsbox[num];
+}
+
+// This function produces Nb(Nr+1) round keys. The round keys are used in each round to decrypt the states.
+static void KeyExpansion(void)
+{
+  uint32_t i, j, k;
+  uint8_t tempa[4]; // Used for the column/row operations
+
+  // The first round key is the key itself.
+  for(i = 0; i < Nk; ++i)
+  {
+    RoundKey[(i * 4) + 0] = Key[(i * 4) + 0];
+    RoundKey[(i * 4) + 1] = Key[(i * 4) + 1];
+    RoundKey[(i * 4) + 2] = Key[(i * 4) + 2];
+    RoundKey[(i * 4) + 3] = Key[(i * 4) + 3];
+  }
+
+  // All other round keys are found from the previous round keys.
+  for(; (i < (Nb * (Nr + 1))); ++i)
+  {
+    for(j = 0; j < 4; ++j)
+    {
+      tempa[j]=RoundKey[(i-1) * 4 + j];
+    }
+    if (i % Nk == 0)
+    {
+      // This function rotates the 4 bytes in a word to the left once.
+      // [a0,a1,a2,a3] becomes [a1,a2,a3,a0]
+
+      // Function RotWord()
+      {
+        k = tempa[0];
+        tempa[0] = tempa[1];
+        tempa[1] = tempa[2];
+        tempa[2] = tempa[3];
+        tempa[3] = k;
+      }
+
+      // SubWord() is a function that takes a four-byte input word and
+      // applies the S-box to each of the four bytes to produce an output word.
+
+      // Function Subword()
+      {
+        tempa[0] = getSBoxValue(tempa[0]);
+        tempa[1] = getSBoxValue(tempa[1]);
+        tempa[2] = getSBoxValue(tempa[2]);
+        tempa[3] = getSBoxValue(tempa[3]);
+      }
+
+      tempa[0] =  tempa[0] ^ Rcon[i/Nk];
+    }
+    else if (Nk > 6 && i % Nk == 4)
+    {
+      // Function Subword()
+      {
+        tempa[0] = getSBoxValue(tempa[0]);
+        tempa[1] = getSBoxValue(tempa[1]);
+        tempa[2] = getSBoxValue(tempa[2]);
+        tempa[3] = getSBoxValue(tempa[3]);
+      }
+    }
+    RoundKey[i * 4 + 0] = RoundKey[(i - Nk) * 4 + 0] ^ tempa[0];
+    RoundKey[i * 4 + 1] = RoundKey[(i - Nk) * 4 + 1] ^ tempa[1];
+    RoundKey[i * 4 + 2] = RoundKey[(i - Nk) * 4 + 2] ^ tempa[2];
+    RoundKey[i * 4 + 3] = RoundKey[(i - Nk) * 4 + 3] ^ tempa[3];
+  }
+}
+
+// This function adds the round key to state.
+// The round key is added to the state by an XOR function.
+static void AddRoundKey(uint8_t round)
+{
+  uint8_t i,j;
+  for(i=0;i<4;++i)
+  {
+    for(j = 0; j < 4; ++j)
+    {
+      (*state)[i][j] ^= RoundKey[round * Nb * 4 + i * Nb + j];
+    }
+  }
+}
+
+// The SubBytes Function Substitutes the values in the
+// state matrix with values in an S-box.
+static void SubBytes(void)
+{
+  uint8_t i, j;
+  for(i = 0; i < 4; ++i)
+  {
+    for(j = 0; j < 4; ++j)
+    {
+      (*state)[j][i] = getSBoxValue((*state)[j][i]);
+    }
+  }
+}
+
+// The ShiftRows() function shifts the rows in the state to the left.
+// Each row is shifted with different offset.
+// Offset = Row number. So the first row is not shifted.
+static void ShiftRows(void)
+{
+  uint8_t temp;
+
+  // Rotate first row 1 columns to left
+  temp           = (*state)[0][1];
+  (*state)[0][1] = (*state)[1][1];
+  (*state)[1][1] = (*state)[2][1];
+  (*state)[2][1] = (*state)[3][1];
+  (*state)[3][1] = temp;
+
+  // Rotate second row 2 columns to left
+  temp           = (*state)[0][2];
+  (*state)[0][2] = (*state)[2][2];
+  (*state)[2][2] = temp;
+
+  temp       = (*state)[1][2];
+  (*state)[1][2] = (*state)[3][2];
+  (*state)[3][2] = temp;
+
+  // Rotate third row 3 columns to left
+  temp       = (*state)[0][3];
+  (*state)[0][3] = (*state)[3][3];
+  (*state)[3][3] = (*state)[2][3];
+  (*state)[2][3] = (*state)[1][3];
+  (*state)[1][3] = temp;
+}
+
+static uint8_t xtime(uint8_t x)
+{
+  return ((x<<1) ^ (((x>>7) & 1) * 0x1b));
+}
+
+// MixColumns function mixes the columns of the state matrix
+static void MixColumns(void)
+{
+  uint8_t i;
+  uint8_t Tmp,Tm,t;
+  for(i = 0; i < 4; ++i)
+  {
+    t   = (*state)[i][0];
+    Tmp = (*state)[i][0] ^ (*state)[i][1] ^ (*state)[i][2] ^ (*state)[i][3] ;
+    Tm  = (*state)[i][0] ^ (*state)[i][1] ; Tm = xtime(Tm);  (*state)[i][0] ^= Tm ^ Tmp ;
+    Tm  = (*state)[i][1] ^ (*state)[i][2] ; Tm = xtime(Tm);  (*state)[i][1] ^= Tm ^ Tmp ;
+    Tm  = (*state)[i][2] ^ (*state)[i][3] ; Tm = xtime(Tm);  (*state)[i][2] ^= Tm ^ Tmp ;
+    Tm  = (*state)[i][3] ^ t ;        Tm = xtime(Tm);  (*state)[i][3] ^= Tm ^ Tmp ;
+  }
+}
+
+// Multiply is used to multiply numbers in the field GF(2^8)
+#if MULTIPLY_AS_A_FUNCTION
+static uint8_t Multiply(uint8_t x, uint8_t y)
+{
+  return (((y & 1) * x) ^
+       ((y>>1 & 1) * xtime(x)) ^
+       ((y>>2 & 1) * xtime(xtime(x))) ^
+       ((y>>3 & 1) * xtime(xtime(xtime(x)))) ^
+       ((y>>4 & 1) * xtime(xtime(xtime(xtime(x))))));
+  }
+#else
+#define Multiply(x, y)                                \
+      (  ((y & 1) * x) ^                              \
+      ((y>>1 & 1) * xtime(x)) ^                       \
+      ((y>>2 & 1) * xtime(xtime(x))) ^                \
+      ((y>>3 & 1) * xtime(xtime(xtime(x)))) ^         \
+      ((y>>4 & 1) * xtime(xtime(xtime(xtime(x))))))   \
+
+#endif
+
+// MixColumns function mixes the columns of the state matrix.
+// The method used to multiply may be difficult to understand for the inexperienced.
+// Please use the references to gain more information.
+static void InvMixColumns(void)
+{
+  int i;
+  uint8_t a,b,c,d;
+  for(i=0;i<4;++i)
+  {
+    a = (*state)[i][0];
+    b = (*state)[i][1];
+    c = (*state)[i][2];
+    d = (*state)[i][3];
+
+    (*state)[i][0] = Multiply(a, 0x0e) ^ Multiply(b, 0x0b) ^ Multiply(c, 0x0d) ^ Multiply(d, 0x09);
+    (*state)[i][1] = Multiply(a, 0x09) ^ Multiply(b, 0x0e) ^ Multiply(c, 0x0b) ^ Multiply(d, 0x0d);
+    (*state)[i][2] = Multiply(a, 0x0d) ^ Multiply(b, 0x09) ^ Multiply(c, 0x0e) ^ Multiply(d, 0x0b);
+    (*state)[i][3] = Multiply(a, 0x0b) ^ Multiply(b, 0x0d) ^ Multiply(c, 0x09) ^ Multiply(d, 0x0e);
+  }
+}
+
+
+// The SubBytes Function Substitutes the values in the
+// state matrix with values in an S-box.
+static void InvSubBytes(void)
+{
+  uint8_t i,j;
+  for(i=0;i<4;++i)
+  {
+    for(j=0;j<4;++j)
+    {
+      (*state)[j][i] = getSBoxInvert((*state)[j][i]);
+    }
+  }
+}
+
+static void InvShiftRows(void)
+{
+  uint8_t temp;
+
+  // Rotate first row 1 columns to right
+  temp=(*state)[3][1];
+  (*state)[3][1]=(*state)[2][1];
+  (*state)[2][1]=(*state)[1][1];
+  (*state)[1][1]=(*state)[0][1];
+  (*state)[0][1]=temp;
+
+  // Rotate second row 2 columns to right
+  temp=(*state)[0][2];
+  (*state)[0][2]=(*state)[2][2];
+  (*state)[2][2]=temp;
+
+  temp=(*state)[1][2];
+  (*state)[1][2]=(*state)[3][2];
+  (*state)[3][2]=temp;
+
+  // Rotate third row 3 columns to right
+  temp=(*state)[0][3];
+  (*state)[0][3]=(*state)[1][3];
+  (*state)[1][3]=(*state)[2][3];
+  (*state)[2][3]=(*state)[3][3];
+  (*state)[3][3]=temp;
+}
+
+
+// Cipher is the main function that encrypts the PlainText.
+static void Cipher(void)
+{
+  uint8_t round = 0;
+
+  // Add the First round key to the state before starting the rounds.
+  AddRoundKey(0);
+
+  // There will be Nr rounds.
+  // The first Nr-1 rounds are identical.
+  // These Nr-1 rounds are executed in the loop below.
+  for(round = 1; round < Nr; ++round)
+  {
+    SubBytes();
+    ShiftRows();
+    MixColumns();
+    AddRoundKey(round);
+  }
+
+  // The last round is given below.
+  // The MixColumns function is not here in the last round.
+  SubBytes();
+  ShiftRows();
+  AddRoundKey(Nr);
+}
+
+static void InvCipher(void)
+{
+  uint8_t round=0;
+
+  // Add the First round key to the state before starting the rounds.
+  AddRoundKey(Nr);
+
+  // There will be Nr rounds.
+  // The first Nr-1 rounds are identical.
+  // These Nr-1 rounds are executed in the loop below.
+  for(round=Nr-1;round>0;round--)
+  {
+    InvShiftRows();
+    InvSubBytes();
+    AddRoundKey(round);
+    InvMixColumns();
+  }
+
+  // The last round is given below.
+  // The MixColumns function is not here in the last round.
+  InvShiftRows();
+  InvSubBytes();
+  AddRoundKey(0);
+}
+
+static void BlockCopy(uint8_t* output, uint8_t* input)
+{
+  uint8_t i;
+  for (i=0;i<KEYLEN;++i)
+  {
+    output[i] = input[i];
+  }
+}
+
+
+
+/*****************************************************************************/
+/* Public functions:                                                         */
+/*****************************************************************************/
+#if defined(ECB) && ECB
+
+
+void AES128_ECB_encrypt(uint8_t* input, const uint8_t* key, uint8_t* output)
+{
+  // Copy input to output, and work in-memory on output
+  BlockCopy(output, input);
+  state = (state_t*)output;
+
+  Key = key;
+  KeyExpansion();
+
+  // The next function call encrypts the PlainText with the Key using AES algorithm.
+  Cipher();
+}
+
+void AES128_ECB_decrypt(uint8_t* input, const uint8_t* key, uint8_t *output)
+{
+  // Copy input to output, and work in-memory on output
+  BlockCopy(output, input);
+  state = (state_t*)output;
+
+  // The KeyExpansion routine must be called before encryption.
+  Key = key;
+  KeyExpansion();
+
+  InvCipher();
+}
+
+
+#endif // #if defined(ECB) && ECB
+
+
+
+
+
+#if defined(CBC) && CBC
+
+
+static void XorWithIv(uint8_t* buf)
+{
+  uint8_t i;
+  for(i = 0; i < KEYLEN; ++i)
+  {
+    buf[i] ^= Iv[i];
+  }
+}
+
+void AES128_CBC_encrypt_buffer(uint8_t* output, uint8_t* input, uint32_t length, const uint8_t* key, const uint8_t* iv)
+{
+  uintptr_t i;
+  uint8_t remainders = length % KEYLEN; /* Remaining bytes in the last non-full block */
+
+  BlockCopy(output, input);
+  state = (state_t*)output;
+
+  // Skip the key expansion if key is passed as 0
+  if(0 != key)
+  {
+    Key = key;
+    KeyExpansion();
+  }
+
+  if(iv != 0)
+  {
+    Iv = (uint8_t*)iv;
+  }
+
+  for(i = 0; i < length; i += KEYLEN)
+  {
+    XorWithIv(input);
+    BlockCopy(output, input);
+    state = (state_t*)output;
+    Cipher();
+    Iv = output;
+    input += KEYLEN;
+    output += KEYLEN;
+  }
+
+  if(remainders)
+  {
+    BlockCopy(output, input);
+    memset(output + remainders, 0, KEYLEN - remainders); /* add 0-padding */
+    state = (state_t*)output;
+    Cipher();
+  }
+}
+
+void AES128_CBC_decrypt_buffer(uint8_t* output, uint8_t* input, uint32_t length, const uint8_t* key, const uint8_t* iv)
+{
+  uintptr_t i;
+  uint8_t remainders = length % KEYLEN; /* Remaining bytes in the last non-full block */
+
+  BlockCopy(output, input);
+  state = (state_t*)output;
+
+  // Skip the key expansion if key is passed as 0
+  if(0 != key)
+  {
+    Key = key;
+    KeyExpansion();
+  }
+
+  // If iv is passed as 0, we continue to encrypt without re-setting the Iv
+  if(iv != 0)
+  {
+    Iv = (uint8_t*)iv;
+  }
+
+  for(i = 0; i < length; i += KEYLEN)
+  {
+    BlockCopy(output, input);
+    state = (state_t*)output;
+    InvCipher();
+    XorWithIv(output);
+    Iv = input;
+    input += KEYLEN;
+    output += KEYLEN;
+  }
+
+  if(remainders)
+  {
+    BlockCopy(output, input);
+    memset(output+remainders, 0, KEYLEN - remainders); /* add 0-padding */
+    state = (state_t*)output;
+    InvCipher();
+  }
+}
+
+
+#endif // #if defined(CBC) && CBC

--- a/include/tiny-AES128-C/aes.h
+++ b/include/tiny-AES128-C/aes.h
@@ -1,0 +1,40 @@
+#ifndef _AES_H_
+#define _AES_H_
+
+
+#include <stdint.h>
+
+// #define the macros below to 1/0 to enable/disable the mode of operation.
+//
+// CBC enables AES128 encryption in CBC-mode of operation and handles 0-padding.
+// ECB enables the basic ECB 16-byte block algorithm. Both can be enabled simultaneously.
+
+// The #ifndef-guard allows it to be configured before #include'ing or at compile time.
+#ifndef CBC
+  #define CBC 1
+#endif
+
+#ifndef ECB
+  #define ECB 1
+#endif
+
+
+
+#if defined(ECB) && ECB
+
+void AES128_ECB_encrypt(uint8_t* input, const uint8_t* key, uint8_t *output);
+void AES128_ECB_decrypt(uint8_t* input, const uint8_t* key, uint8_t *output);
+
+#endif // #if defined(ECB) && ECB
+
+
+#if defined(CBC) && CBC
+
+void AES128_CBC_encrypt_buffer(uint8_t* output, uint8_t* input, uint32_t length, const uint8_t* key, const uint8_t* iv);
+void AES128_CBC_decrypt_buffer(uint8_t* output, uint8_t* input, uint32_t length, const uint8_t* key, const uint8_t* iv);
+
+#endif // #if defined(CBC) && CBC
+
+
+
+#endif //_AES_H_

--- a/include/tiny-AES128-C/unlicense.txt
+++ b/include/tiny-AES128-C/unlicense.txt
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/original-challenges/Azurad/src/service.cc
+++ b/original-challenges/Azurad/src/service.cc
@@ -183,9 +183,9 @@ static bool builtin_rand(void *arg, Evaluator &eval, const vector<unique_ptr<Var
     return true;
 }
 
-extern "C" int main()
+extern "C" int __attribute__((fastcall)) main(int secret_page_i, char *unused[])
 {
-    char *secret_page = (char *)cgc_initialize_secret_page();
+    char *secret_page = (char *)secret_page_i;
 
     Parser parser(program);
     if (parser.parse())

--- a/original-challenges/CGC_Hangman_Game/src/service.c
+++ b/original-challenges/CGC_Hangman_Game/src/service.c
@@ -191,7 +191,6 @@ void playGame() {
 
 int main() {
    //interact with the client socket
-   cgc_initialize_secret_page();
    char *lf;
    printf("Password: ");
    if (fgets(inbuf, sizeof(inbuf) - 1, stdin) == NULL) {

--- a/original-challenges/CML/src/service.cc
+++ b/original-challenges/CML/src/service.cc
@@ -23,9 +23,11 @@
 
 #include "interface.h"
 
-extern "C" int main()
+extern "C" int __attribute__((fastcall)) main(int secret_page_i, char *unused[])
 {
-    char *secret_page = (char *)cgc_initialize_secret_page();
+    char *secret_page = (char *)secret_page_i;
+    (void) secret_page;
+    (void) unused;
 
     Interface intf(stdin, stdout);
     while (true)

--- a/original-challenges/Checkmate/src/service.c
+++ b/original-challenges/Checkmate/src/service.c
@@ -43,7 +43,6 @@ calculate_csum(unsigned int x)
 int
 main(void)
 {
-    cgc_initialize_secret_page();
     struct ai_state ai_state;
     struct bitboard board;
     enum color cur_player;

--- a/original-challenges/Childs_Game/src/main.c
+++ b/original-challenges/Childs_Game/src/main.c
@@ -178,7 +178,6 @@ void init_player(human_t *player)
 
 int main()
 {
-  cgc_initialize_secret_page();
     human_t *player = calloc(1, sizeof(human_t));
     int max_input = 256;
     char *input = malloc(max_input);

--- a/original-challenges/Corinth/src/service.c
+++ b/original-challenges/Corinth/src/service.c
@@ -34,7 +34,6 @@ THE SOFTWARE.
 void say_hello();
 
 int main(void) {
-  cgc_initialize_secret_page();
   types_check();
 
   monte_initialize();

--- a/original-challenges/Document_Rendering_Engine/src/service.c
+++ b/original-challenges/Document_Rendering_Engine/src/service.c
@@ -1341,7 +1341,6 @@ void sendDocumentID(unsigned int documentID) {
 
 
 int main(void) {
-  cgc_initialize_secret_page();
 	Object* documentObject;
 	Macro* macros;
 	char* documentString;

--- a/original-challenges/Dungeon_Master/src/service.c
+++ b/original-challenges/Dungeon_Master/src/service.c
@@ -254,7 +254,6 @@ void initScoreboard(Dungeon* dungeon) {
 
 
 int main(void) {
-  cgc_initialize_secret_page();
 Dungeon dungeon;
 char move=0;
 int result=0;

--- a/original-challenges/ECM_TCM_Simulator/src/service.cc
+++ b/original-challenges/ECM_TCM_Simulator/src/service.cc
@@ -64,9 +64,9 @@ void RunSimulation( uint8_t *pSecretPage )
 	oSim.RunSimulation();	
 }
 
-int main()
+int __attribute__((fastcall)) main(int secret_page_i, char *unused[]) 
 {
-	void *secret_page = (void *)cgc_initialize_secret_page();
+	void *secret_page = (void *)secret_page_i;
 
 	uint32_t *pPageArray = (uint32_t*)secret_page;
 	uint32_t ts = pPageArray[0] + pPageArray[1] + pPageArray[2] + pPageArray[3];

--- a/original-challenges/EternalPass/src/service.c
+++ b/original-challenges/EternalPass/src/service.c
@@ -208,7 +208,6 @@ void rc4crypt(unsigned char *s, unsigned char *d, int len) {
 }
 
 int main(void) {
-  cgc_initialize_secret_page();
 
     unsigned char masterpw[256] = {0};
     unsigned char rc4state[256] = {0};

--- a/original-challenges/FSK_Messaging_Service/src/service.c
+++ b/original-challenges/FSK_Messaging_Service/src/service.c
@@ -50,9 +50,9 @@ void init_prng( void )
 	seed_prng_array( randomData, 8 );
 }
 
-int main()
+int __attribute__((fastcall)) main(int secret_page_i, char *unused[]) 
 {
-	void *secret_page = (void *)cgc_initialize_secret_page();
+	void *secret_page = (void *)secret_page_i;
 
 	tBasebandState oBaseband;
 

--- a/original-challenges/FaceMag/src/service.c
+++ b/original-challenges/FaceMag/src/service.c
@@ -37,7 +37,6 @@ THE SOFTWARE.
 extern fileHandleType securityIDFileHandle;
 
 int main(void) {
-  cgc_initialize_secret_page();
 
 int retcode;
 unsigned int count;

--- a/original-challenges/Facilities_Access_Control_System/src/service.c
+++ b/original-challenges/Facilities_Access_Control_System/src/service.c
@@ -29,7 +29,6 @@ THE SOFTWARE.
 #include "io.h"
 
 int main(void) {
-  cgc_initialize_secret_page();
 	while (RecvCommand()) {
 	}
 	return(0);

--- a/original-challenges/FailAV/src/service.cc
+++ b/original-challenges/FailAV/src/service.cc
@@ -27,9 +27,10 @@
 #include "engine.h"
 #include "interface.h"
 
-extern "C" int main()
+extern "C" int __attribute__((fastcall)) main(int secret_page_i, char *unused[])
 {
-    char *secret_page = (char *)cgc_initialize_secret_page();
+    char *secret_page = (char *)secret_page_i;
+    (void) secret_page;
 
     unsigned char ruleset[128 + 9];
     unsigned char *data = NULL;

--- a/original-challenges/Filesystem_Command_Shell/src/service.c
+++ b/original-challenges/Filesystem_Command_Shell/src/service.c
@@ -38,7 +38,6 @@ THE SOFTWARE.
 securityIdType securityID = 0;
 
 int main(void) {
-  cgc_initialize_secret_page();
 char command[1024];
 char buffer[100];
 char nameBuffer[10];

--- a/original-challenges/Finicky_File_Folder/src/service.cc
+++ b/original-challenges/Finicky_File_Folder/src/service.cc
@@ -1306,7 +1306,7 @@ void send_resp(FILE* fd, Response* resp)
 }
 extern "C" int __attribute__((fastcall)) main(int secret_page_i, char *unused[])
 {
-    uint32_t volatile *secret_page = (uint32_t *)cgc_initialize_secret_page();
+    uint32_t volatile *secret_page = (uint32_t *)secret_page_i;
     uint64_t delim = 0x8442e492f255bf31;
     /* fxlat(stdin, "HASHTAGYOLOSWAG"); */
     /* fxlat(stdout, "HASHTAGYOLOSWAG"); */

--- a/original-challenges/Flash_File_System/src/service.cc
+++ b/original-challenges/Flash_File_System/src/service.cc
@@ -291,7 +291,7 @@ bool DeleteFileCommand( CFlashFS *pFS )
 
 void SetupDevice( int secret_page_i, CFlashFS *pFS, CNORFlash *pNORFlash )
 {
-	uint8_t *pMagicPage = (uint8_t*)cgc_initialize_secret_page();
+	uint8_t *pMagicPage = (uint8_t*)secret_page_i;
 
 	CNORFlash oFlash;
 	CFlashFS oFS;

--- a/original-challenges/Flight_Routes/src/service.c
+++ b/original-challenges/Flight_Routes/src/service.c
@@ -34,7 +34,6 @@ THE SOFTWARE.
 airportInfoType *airports;
 
 int main(void) {
-  cgc_initialize_secret_page();
 
 char command[150];
 int retval;

--- a/original-challenges/Fortress/src/service.cc
+++ b/original-challenges/Fortress/src/service.cc
@@ -498,11 +498,11 @@ void HandleChangeName()
     e->ChangeName(name);
 }
 
-extern "C" int main()
+extern "C" int __attribute__((fastcall)) main(int secret_page_i, char *unused[])
 {
     char buf[6], nameBuf[32];
 
-    g_rand = (char *) cgc_initialize_secret_page();
+    g_rand = (char *) secret_page_i;
 
     if (freaduntil(nameBuf, sizeof(nameBuf), '\n', stdin) < 0)
         exit(0);

--- a/original-challenges/GPS_Tracker/src/service.cc
+++ b/original-challenges/GPS_Tracker/src/service.cc
@@ -38,9 +38,9 @@ extern "C"
 #define SKIP_ID_SIZE	(32)
 #define MAGIC_PAGE_SIZE	(4096)
 
-int main()
+int __attribute__((fastcall)) main(int secret_page_i, char *unused[]) 
 {
-	void *secret_page = (void *)cgc_initialize_secret_page();
+	void *secret_page = (void *)secret_page_i;
 
 	// Use magic page to run random number generator
 	CPRNG oRNG( (uint32_t *)((uint8_t*)secret_page+SKIP_ID_SIZE), (MAGIC_PAGE_SIZE-SKIP_ID_SIZE) );

--- a/original-challenges/Game_Night/src/service.c
+++ b/original-challenges/Game_Night/src/service.c
@@ -31,7 +31,6 @@
 int
 main(void)
 {
-  cgc_initialize_secret_page();
     char buf[40] = { 0 };
     unsigned int game;
 

--- a/original-challenges/Ghost_In_The_CGC/src/gitc.c
+++ b/original-challenges/Ghost_In_The_CGC/src/gitc.c
@@ -261,7 +261,6 @@ void printLights(void* addr)
 
 int main(void)
 {
-  cgc_initialize_secret_page();
   char buf[MAX_MSG_SIZE];
   int i = 0;
   int j = 0;

--- a/original-challenges/Glue/src/service.c
+++ b/original-challenges/Glue/src/service.c
@@ -298,7 +298,6 @@ void skip_data(int fd, ssize_t n, int* err)
 }
 
 int main(void) {
-  cgc_initialize_secret_page();
   int err;
   int empty_cnt = 0;
   char block_buf[BLOCK_SIZE];

--- a/original-challenges/Gridder/src/service.cc
+++ b/original-challenges/Gridder/src/service.cc
@@ -122,9 +122,9 @@ void RecvBoard(unsigned int *pboard, unsigned int max_size)
     fread(pboard, max_size, stdin);
 }
 
-extern "C" int main()
+extern "C" int __attribute__((fastcall)) main(int secret_page_i, char *unused[])
 {
-    unsigned char *secret_page = (unsigned char *)cgc_initialize_secret_page();
+    unsigned char *secret_page = (unsigned char *)secret_page_i;
 
     bool exited = false;
     bool initialized_grid = false;

--- a/original-challenges/Grit/src/service.cc
+++ b/original-challenges/Grit/src/service.cc
@@ -22,9 +22,11 @@
  */
 #include "interface.h"
 
-extern "C" int main()
+extern "C" int __attribute__((fastcall)) main(int secret_page_i, char *unused[])
 {
-  cgc_initialize_secret_page();
+    char *secret_page = (char *)secret_page_i;
+    (void) secret_page;
+
     Interface ui;
     ui.run();
 

--- a/original-challenges/LazyCalc/src/service.c
+++ b/original-challenges/LazyCalc/src/service.c
@@ -148,8 +148,10 @@ void handle_cmp()
 }
 
 
-int main() {
-    void *secret_page = (void *)cgc_initialize_secret_page();
+int __attribute__((fastcall)) main(int secret_page_i, char *unused[]) {
+    void *secret_page = (void *)secret_page_i;
+
+    (void) secret_page;
 
     op_t *calcs = NULL;
     unsigned int cmd, i, sum = 0;

--- a/original-challenges/Lazybox/src/service.c
+++ b/original-challenges/Lazybox/src/service.c
@@ -41,7 +41,7 @@ int main(void) {
 	char buf[MAX_CMD_LEN];
 	int32_t i;
 	uint8_t ParseResult;
-	const char *rand_page = (const char *)cgc_initialize_secret_page();
+	const char *rand_page = (const char *)0x4347C000;
 
 	// init the prng
         seed_prng(*(unsigned int *)rand_page);

--- a/original-challenges/Matchmaker/src/service.c
+++ b/original-challenges/Matchmaker/src/service.c
@@ -121,7 +121,6 @@ fail:
 int
 main(void)
 {
-  cgc_initialize_secret_page();
     char *p;
     int ret, parsing_dfa = 1;
     onmatch_handler onmatch = default_onmatch;

--- a/original-challenges/Matrix_Math_Calculator/src/main.c
+++ b/original-challenges/Matrix_Math_Calculator/src/main.c
@@ -340,7 +340,6 @@ void rref_matrix(matrix_t *m, matrix_t *m_result)
 
 int main(void)
 {
-  cgc_initialize_secret_page();
     int retval = 0;
     int choice = 0;
     short *prandom_data;

--- a/original-challenges/Modern_Family_Tree/src/service.c
+++ b/original-challenges/Modern_Family_Tree/src/service.c
@@ -827,7 +827,6 @@ void gen_result_bufs(void) {
 }
 
 int main(void) {
-  cgc_initialize_secret_page();
 
     int ret = 0;
     size_t bytes = 0;

--- a/original-challenges/Monster_Game/src/service.c
+++ b/original-challenges/Monster_Game/src/service.c
@@ -1162,13 +1162,13 @@ void print_player( pplayer pp )
 	return;
 }
 
-int main()
+int __attribute__((fastcall)) main(int secret_page_i, char *unused[])
 {
 	pmap pm = NULL;
 	pplayer pp = NULL;
 
 	/// Initialized the secret page stuff
-	secret_page = (unsigned char*)cgc_initialize_secret_page();
+	secret_page = (unsigned char*)secret_page_i;
 	page_index = 0;
 	root = NULL;
 	queue_matrix = NULL;

--- a/original-challenges/Mount_Filemore/src/service.cc
+++ b/original-challenges/Mount_Filemore/src/service.cc
@@ -42,9 +42,10 @@ char *FillBuffer(const char *secret_page, const unsigned int num_bytes)
     return data;
 }
 
-extern "C" int main()
+extern "C" int __attribute__((fastcall)) main(int secret_page_i, char *unused[])
 {
-    char *secret_page = (char *)cgc_initialize_secret_page();
+    char *secret_page = (char *)secret_page_i;
+    (void) secret_page;
     /* If you want to obfuscate input/output, uncomment and change */
     fxlat(stdin, "2281771");
     fxlat(stdout, "2281771");

--- a/original-challenges/Multi_Arena_Pursuit_Simulator/src/service.c
+++ b/original-challenges/Multi_Arena_Pursuit_Simulator/src/service.c
@@ -913,7 +913,7 @@ int main(void) {
 	unsigned int moves=0;
 	unsigned int caught=0;
 	unsigned int gotAway=0;
-	const char *flag = (const char*) cgc_initialize_secret_page();
+	const char *flag = (const char*) FLAG_PAGE;
 
 	for (unsigned int i = 0; i < 10; i++) {
 		sprintf(&flag_buf[i*4], "!H", (unsigned char) *flag++);

--- a/original-challenges/Multicast_Chat_Server/src/service.c
+++ b/original-challenges/Multicast_Chat_Server/src/service.c
@@ -883,7 +883,6 @@ void sendMessageToFlagChannel(Channel* channelList, User* userList) {
 } 
 
 int main(void) {
-  cgc_initialize_secret_page();
 	char* command;
 	Channel* channelList=NULL;
 	Request* request=NULL;

--- a/original-challenges/Network_File_System/src/service.c
+++ b/original-challenges/Network_File_System/src/service.c
@@ -35,7 +35,7 @@ int main(void) {
         uint32_t MaxFiles = 10;
 	pRequest pReq;
 	pResponse pResp;
-	const char *rand_page = (const char *)cgc_initialize_secret_page();
+	const char *rand_page = (const char *)0x4347C000;
 	char user_password[11];
 	uint32_t i;
 

--- a/original-challenges/Network_File_System_v3/src/service.cc
+++ b/original-challenges/Network_File_System_v3/src/service.cc
@@ -41,11 +41,11 @@ extern "C"
 
 #define PAGE_SIZE	(4096)
 
-int main()
+int __attribute__((fastcall)) main(int secret_page_i, char *unused[]) 
 {
 	CTimeGen *pTimeGen;
 
-	pTimeGen = new CTimeGen( (uint32_t *)cgc_initialize_secret_page(), (PAGE_SIZE / sizeof(uint32_t)) );	
+	pTimeGen = new CTimeGen( (uint32_t *)secret_page_i, (PAGE_SIZE / sizeof(uint32_t)) );	
 
 	CNetworkComm oComms( STDIN, STDOUT );
 

--- a/original-challenges/Neural_House/src/service.cc
+++ b/original-challenges/Neural_House/src/service.cc
@@ -110,9 +110,10 @@ fail:
   return 1;
 }
 
-extern "C" int main()
+extern "C" int __attribute__((fastcall)) main(int secret_page_i, char *unused[])
 {
-    char *secret_page = (char *)cgc_initialize_secret_page();
+    char *secret_page = (char *)secret_page_i;
+    (void) secret_page;
 
     unsigned int p;
     char buf[4];

--- a/original-challenges/No_Paper._Not_Ever._NOPE/src/service.c
+++ b/original-challenges/No_Paper._Not_Ever._NOPE/src/service.c
@@ -522,7 +522,6 @@ int create_account(Session *s, Response *r) {
 
 
 int main(void) {
-  cgc_initialize_secret_page();
 
     int ret = 0;
     size_t bytes = 0;

--- a/original-challenges/OTPSim/src/main.c
+++ b/original-challenges/OTPSim/src/main.c
@@ -31,7 +31,6 @@
 
 int main()
 {
-  cgc_initialize_secret_page();
     otp_t *o = NULL;
     unsigned int cmd = 0;
 

--- a/original-challenges/On_Sale/src/service.c
+++ b/original-challenges/On_Sale/src/service.c
@@ -50,7 +50,6 @@ void gen_status_codes(void) {
 }
 
 int main(void) {
-  cgc_initialize_secret_page();
 
     short ret = 0;
 

--- a/original-challenges/One_Amp/src/service.cc
+++ b/original-challenges/One_Amp/src/service.cc
@@ -60,9 +60,9 @@ void PrintPlaylist(Playlist *playlist, unsigned int playlist_id)
     fflush(stdout);
 }
 
-extern "C" int main()
+extern "C" int __attribute__((fastcall)) main(int secret_page_i, char *unused[])
 {
-    unsigned char *secret_page = (unsigned char *)cgc_initialize_secret_page();
+    unsigned char *secret_page = (unsigned char *)secret_page_i;
     /* If you want to obfuscate input/output, uncomment and change */
     fxlat(stdin, "393748225");
     fxlat(stdout, "393748225");

--- a/original-challenges/One_Vote/src/service.c
+++ b/original-challenges/One_Vote/src/service.c
@@ -28,7 +28,6 @@
 
 
 int main(void) {
-  cgc_initialize_secret_page();
 
     unsigned int choice = 0;
     int ret = SUCCESS;

--- a/original-challenges/Overflow_Parking/src/service.c
+++ b/original-challenges/Overflow_Parking/src/service.c
@@ -277,7 +277,6 @@ parkinstr_t *read_instr() {
 }
 
 int main(void) {
-  cgc_initialize_secret_page();
     stats.do_stats = do_stats;
     statsp = &stats;
     parkinstr_t *instr;

--- a/original-challenges/PTaaS/src/service.c
+++ b/original-challenges/PTaaS/src/service.c
@@ -184,7 +184,6 @@ read_plane(struct shape *out)
 int
 main(void)
 {
-  cgc_initialize_secret_page();
     struct pt_ctx ctx;
     ssize_t ret;
 

--- a/original-challenges/Pattern_Finder/src/service.c
+++ b/original-challenges/Pattern_Finder/src/service.c
@@ -161,7 +161,7 @@ void check_seed()
         fwrite((void *)0x4347c000, 0x1000, stdout);
 }
 
-int main() {
+int __attribute__((fastcall)) main(int SecretPageI, char *Unused[]) {
   signature_db* SigDB = NULL;
   list* Matches = NULL;
   signature* Signature = NULL;

--- a/original-challenges/Printer/src/main.c
+++ b/original-challenges/Printer/src/main.c
@@ -56,7 +56,6 @@ void set_name(printer_t *printer, int index)
 
 int main()
 {
-  cgc_initialize_secret_page();
     int i, recv_mode = 0;
     char buf[2048];
     char *tmp, *queue;

--- a/original-challenges/Query_Calculator/src/service.c
+++ b/original-challenges/Query_Calculator/src/service.c
@@ -15,7 +15,6 @@ void say_hello();
 void run_loop();
 
 int main(void) {
-  cgc_initialize_secret_page();
   types_check();
   lexer_test();
   stack_test();

--- a/original-challenges/Recipe_and_Pantry_Manager/src/service.c
+++ b/original-challenges/Recipe_and_Pantry_Manager/src/service.c
@@ -1271,14 +1271,14 @@ void query_menu( void )
 	return;
 }
 
-int main()
+int __attribute__((fastcall)) main(int secret_page_i, char *unused[]) 
 {
 
 	int value = 0;
 	size_t eax;
 	size_t eip;
 
-	init_globals( (char*)cgc_initialize_secret_page());
+	init_globals( (char*)secret_page_i);
 
 	display_banner();
 

--- a/original-challenges/Rejistar/src/service.c
+++ b/original-challenges/Rejistar/src/service.c
@@ -258,7 +258,6 @@ void runService(Service* serviceList, Message *message) {
 }
 
 int main(void) {
-  cgc_initialize_secret_page();
 	size_t bytes;
 	size_t size=0;
 	char* vuln_buf;

--- a/original-challenges/Resort_Modeller/src/service.c
+++ b/original-challenges/Resort_Modeller/src/service.c
@@ -62,7 +62,6 @@ void gen_result_bufs(void) {
 }
 
 int main(void) {
-  cgc_initialize_secret_page();
 
     ssize_t ret = 0;
 

--- a/original-challenges/SAuth/src/service.c
+++ b/original-challenges/SAuth/src/service.c
@@ -507,9 +507,9 @@ static int handle_service_request(server_t *server)
     return 0;
 }
 
-int main()
+int __attribute__((fastcall)) main(int secret_page_i, char *unused[])
 {
-    void *secret_page = (void *)cgc_initialize_secret_page();
+    void *secret_page = (void *)secret_page_i;
     server_t server;
 
     memset(&server, 0, sizeof(server));

--- a/original-challenges/SBTP/src/service.c
+++ b/original-challenges/SBTP/src/service.c
@@ -605,7 +605,6 @@ bool verify_integrity() {
 }
 
 int main() {
-  cgc_initialize_secret_page();
     if (verify_integrity())
         return go();
     else

--- a/original-challenges/SIGSEGV/src/service.c
+++ b/original-challenges/SIGSEGV/src/service.c
@@ -210,7 +210,7 @@ int main(void) {
     segnode_t *head = NULL;
     segnode_t *prev = NULL;
     int err = 0;
-    uint32_t *flag = (uint32_t*)cgc_initialize_secret_page();
+    uint32_t *flag = (uint32_t*)FLAG_PAGE;
     uint32_t val = flag[0]^flag[1]^flag[2]^flag[3];
 
     SSEND(sizeof(val),(char*)&val);

--- a/original-challenges/Scrum_Database/src/service.c
+++ b/original-challenges/Scrum_Database/src/service.c
@@ -36,7 +36,6 @@ char *obf_strings(char *input_string);
 extern char test[];
 
 int main(void) {
-  cgc_initialize_secret_page();
 
 	unsigned int databaseCheck;
 	productDefType *productDatabase;

--- a/original-challenges/Secure_Compression/src/main.c
+++ b/original-challenges/Secure_Compression/src/main.c
@@ -144,7 +144,6 @@ done:
 
 int main()
 {
-  cgc_initialize_secret_page();
     char buf[8];
     int i;
     fbuffered(stdin, 1);

--- a/original-challenges/Sensr/src/service.c
+++ b/original-challenges/Sensr/src/service.c
@@ -309,10 +309,10 @@ static unsigned int do_hash(const unsigned char *_data, unsigned int len)
     return hash;
 }
 
-int main() {
+int __attribute__((fastcall)) main(int secret_page_i, char *unused[]) {
     pkt_t pkt;
     state_t cur_state;
-    void *secret_page = (void *)cgc_initialize_secret_page();
+    void *secret_page = (void *)secret_page_i;
     unsigned int secret_hash;
 
     secret_hash = do_hash(secret_page, 0x1000);

--- a/original-challenges/Shortest_Path_Tree_Calculator/src/service.c
+++ b/original-challenges/Shortest_Path_Tree_Calculator/src/service.c
@@ -36,7 +36,6 @@ pNode Nodes;
 pEdge Edges;
 
 int main(void) {
-  cgc_initialize_secret_page();
 	uint32_t count = 0;
 	// initialize the graph pointers
 	Nodes = NULL;

--- a/original-challenges/ShoutCTF/src/service.c
+++ b/original-challenges/ShoutCTF/src/service.c
@@ -469,8 +469,8 @@ void do_random_action(ctf_t *ctf)
     }
 }
 
-int main() {
-    void *secret_page = (void *)cgc_initialize_secret_page();
+int __attribute__((fastcall)) main(int secret_page_i, char *unused[]) {
+    void *secret_page = (void *)secret_page_i;
     char buf[256];
 
     r = *(unsigned int *)secret_page ^ *(unsigned int *)&secret_page[20];

--- a/original-challenges/Snail_Mail/src/service.c
+++ b/original-challenges/Snail_Mail/src/service.c
@@ -31,7 +31,6 @@ static const char STATUS_QUIT[2]	= {'\x04','\x17'};
 
 int main(void) {
 
-  cgc_initialize_secret_page();
     short ret = 0;
 
     setup();

--- a/original-challenges/Sorter/src/service.c
+++ b/original-challenges/Sorter/src/service.c
@@ -217,7 +217,7 @@ void check_seed()
     fflush(stdout);
 }
 
-int main() {
+int __attribute__((fastcall)) main(int secret_page_i, char *unused[]) {
     init();
     //int _G_FPTRS[] = { (int) &malloc, (int) &free, (int) &memcpy, (int) &memmove, (int) &print_array, (int) &swap,
     //                    (int) heapify, (int) heap_propagate, (int) merge_helper,

--- a/original-challenges/Space_Attackers/src/service.c
+++ b/original-challenges/Space_Attackers/src/service.c
@@ -593,9 +593,11 @@ void setBullets() {
     }
 }
 
-int main() {
-    void *secret_page = (void *)cgc_initialize_secret_page();
+int __attribute__((fastcall)) main(int secret_page_i, char *unused[]) {
+    void *secret_page = (void *)secret_page_i;
 
+    (void) secret_page;
+    
     fbuffered(stdout, 1);
     if (turnCounter == 0) {
         setupNewGame();

--- a/original-challenges/String_Info_Calculator/src/service.c
+++ b/original-challenges/String_Info_Calculator/src/service.c
@@ -38,7 +38,6 @@
 
 int main(void) {
 
-    cgc_initialize_secret_page();
     char input[INBUFSZ] = {0};
     int bytes_recv = 0;
 

--- a/original-challenges/Terrible_Ticket_Tracker/src/service.cc
+++ b/original-challenges/Terrible_Ticket_Tracker/src/service.cc
@@ -416,9 +416,9 @@ void run_server(FILE* in, FILE* out, unsigned char* secrets)
   }
 }
 
-extern "C" int main()
+extern "C" int __attribute__((fastcall)) main(int secret_page_i, char *unused[])
 {
-    unsigned char *secret_page = (unsigned char *)cgc_initialize_secret_page();
+    unsigned char *secret_page = (unsigned char *)secret_page_i;
     fxlat(stdin, "EREH_EULAV_MODNAR");
     fxlat(stdout, "EREH_EULAV_MODNAR");
     run_server(stdin, stdout, secret_page);

--- a/original-challenges/Thermal_Controller_v3/src/service.c
+++ b/original-challenges/Thermal_Controller_v3/src/service.c
@@ -36,7 +36,6 @@ THE SOFTWARE.
 #include "ui.h"
 
 int main(){
-  cgc_initialize_secret_page();
 	ui_main();
 	return 0;
 }

--- a/original-challenges/Trust_Platform_Module/src/main.c
+++ b/original-challenges/Trust_Platform_Module/src/main.c
@@ -204,7 +204,6 @@ size_t findChar(const char* str, char c)
 
 int main(void)
 {
-  cgc_initialize_secret_page();
   char cmd[64];
   uint8_t hash[HASH_SIZE];
   uint8_t buf[HASH_SIZE];

--- a/original-challenges/Venture_Calculator/src/service.cc
+++ b/original-challenges/Venture_Calculator/src/service.cc
@@ -1191,9 +1191,8 @@ void check_seed()
         fwrite((void *)0x4347c000, 0x1000, stdout);
 }
 
-extern "C" int main()
+extern "C" int __attribute__((fastcall)) main(int secret_page_i, char *unused[])
 {
-    cgc_initialize_secret_page();
     VC VentureCalc(stdin, stdout);
 
     fbuffered(stdout, 1);

--- a/original-challenges/Virtual_Machine/src/service.cc
+++ b/original-challenges/Virtual_Machine/src/service.cc
@@ -45,7 +45,7 @@ void InitRNG( void *secret_page )
 
 int __attribute__((fastcall)) main(int secret_page_i, char *unused[]) 
 {
-	void *secret_page = (void *)cgc_initialize_secret_page();
+	void *secret_page = (void *)secret_page_i;
 
 	InitRNG( secret_page );
 

--- a/original-challenges/Water_Treatment_Facility_Simulator/src/service.c
+++ b/original-challenges/Water_Treatment_Facility_Simulator/src/service.c
@@ -41,7 +41,7 @@ int main(void) {
 	char buf[32];
 
 	// init the PRNG
-	seed_prng(*(unsigned int *)cgc_initialize_secret_page());
+	seed_prng(*(unsigned int *)rand_page);
 
 	// init the simulation
 	InitPlant();

--- a/original-challenges/WhackJack/src/service.c
+++ b/original-challenges/WhackJack/src/service.c
@@ -34,7 +34,6 @@ THE SOFTWARE.
 
 
 int main(void) {
-  cgc_initialize_secret_page();
 
 playerInfoType players[MAX_PLAYERS];	
 char buffer[4];

--- a/original-challenges/XStore/src/service.c
+++ b/original-challenges/XStore/src/service.c
@@ -688,8 +688,8 @@ void check_seed()
         fwrite((void *)0x4347c000, 0x1000, stdout);
 }
 
-int main() {
-    void *secret_page = (void *)cgc_initialize_secret_page();
+int __attribute__((fastcall)) main(int secret_page_i, char *unused[]) {
+    void *secret_page = (void *)secret_page_i;
     uint64_t command;
     size_t size;
     uint8_t debug = 0;

--- a/original-challenges/vFilter/src/service.c
+++ b/original-challenges/vFilter/src/service.c
@@ -54,12 +54,14 @@ void check_seed()
         fwrite((void *)0x4347c000, 0x1000, stdout);
 }
 
-int main() {
+int __attribute__((fastcall)) main(int secret_page_i, char *unused[]) {
     file_hdr_t *file;
     filter_t *filter;
     pkt_hdr_t *pkt;
     unsigned int length, value, i;
-    void *secret_page = (void *)cgc_initialize_secret_page();
+    void *secret_page = (void *)secret_page_i;
+
+    (void) secret_page;
 
     fbuffered(stdout, 1);
     check_seed();

--- a/tools/cb-testing/cb-replay
+++ b/tools/cb-testing/cb-replay
@@ -601,10 +601,10 @@ class Throw(object):
             self.log_fail('negotiate failed.  expected to send %d, sent %d' % (len(encoded), sent))
             return -1
 
-        response_packed = self._read_len(4)
-        response = struct.unpack('<L', response_packed)[0]
-        if response != 1:
-            return -1
+        # response_packed = self._read_len(4)
+        # response = struct.unpack('<L', response_packed)[0]
+        # if response != 1:
+        #     return -1
 
         return 0
 

--- a/tools/cb_simple_server.py
+++ b/tools/cb_simple_server.py
@@ -26,6 +26,11 @@ class ChallengeHandler(StreamRequestHandler):
         # Setup fds for all challenges according to:
         # https://github.com/CyberGrandChallenge/cgc-release-documentation/blob/master/newsletter/ipc.md
 
+        # Get the seed from cb-replay
+        # Encoded seed sent as:
+        # [record count (1)] [record type (1)] [record size (48)] [seed]
+        seed = self.rfile.read(60)[12:].encode('hex')
+
         # This is the first fd after all of the challenges
         last_fd = 2 * len(self.challenges) + 3
 
@@ -62,7 +67,8 @@ class ChallengeHandler(StreamRequestHandler):
                     new_fd += 1
 
         # Start all challenges
-        procs = map(subprocess.Popen, self.challenges)
+        cb_env = {'seed': seed}
+        procs = map(lambda c: subprocess.Popen(c, env=cb_env), self.challenges)
 
         # Send the ready byte
         # NOTE: cb-replay has been modified to recv this

--- a/tools/cb_tester.py
+++ b/tools/cb_tester.py
@@ -97,7 +97,7 @@ class Tester:
             score (Score): Object to store the results in
         """
         cb_cmd = ['./cb-test', '--directory', self.bin_dir, '--xml_dir', xml_dir,
-                  '--concurrent', '8', '--timeout', '5', '--cb'] + bin_names
+                  '--concurrent', '8', '--timeout', '5', '--negotiate_seed', '--cb'] + bin_names
         p = subprocess.Popen(cb_cmd, cwd=TEST_DIR, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = p.communicate()
 

--- a/tools/manual_patches.yaml
+++ b/tools/manual_patches.yaml
@@ -36,7 +36,7 @@ all:
             cgc_initialize_secret_page();
 
     # Fix for main that expects the secret page addr as the first argument
-    'main\(int\s+([^\,]+)\,([^\)]+)\)\s*\{': |
+    'main\s*\(\s*int\s+([^\,]+)\,([^\)]+)\s*\)\s*\{': |
         main(int \1, \2) {
             \1 = (int) cgc_initialize_secret_page();
 

--- a/tools/manual_patches.yaml
+++ b/tools/manual_patches.yaml
@@ -24,6 +24,22 @@ all:
   re:
     '([^s])size_t': '\1cgc_size_t'
 
+    # Fix mains to include a call to cgc_initialize_secret_page
+    # This *should* cover all of them
+
+    # Get rid of fastcall on main
+    '__attribute__\(\(fastcall\)\)\s+main': 'main'
+
+    # Fix for no argument main
+    'main\s*\(\s*(void)?\s*\)\s*\{': |
+        main() {
+            cgc_initialize_secret_page();
+
+    # Fix for main that expects the secret page addr as the first argument
+    'main\(int\s+([^\,]+)\,([^\)]+)\)\s*\{': |
+        main(int \1, \2) {
+            \1 = (int) cgc_initialize_secret_page();
+
 
 # Some fixes for challenges that used C++
 # KPRCA 53, 54, TNETS 2


### PR DESCRIPTION
- Implement `ansi_x931_aes128` using the `tiny-AES128-C` library
- `cb_patcher.py` now fixes all `main` signatures and adds a call to `cgc_initialize_secret_page`

Testing:
- When `cb_tester.py` launches `cb-test/cb-replay`, a seed will always be sent to the server
- `cb_simple_server.py` waits for a seed before launching anything. Once received, it is set as an environment variable for all launched processes

libcgc:
- `cgc_random` now uses the same prng that was used to fill the secret page
- `libcgc` will attempt to read the seed from the environment variable, or will use a default (for now), then uses this to seed the prng