### PR TITLE
Make cgc_initialize_secret_page a constructor.

### DIFF
--- a/include/libcgc.h
+++ b/include/libcgc.h
@@ -24,6 +24,10 @@ typedef long cgc_ssize_t;
 # define PAGE_SIZE 4096
 #endif
 
+#ifndef CGC_FLAG_PAGE_ADDRESS
+# define CGC_FLAG_PAGE_ADDRESS 0x4347C000
+#endif
+
 #ifndef offsetof
 # define offsetof(TYPE, MEMBER) __builtin_offsetof (TYPE, MEMBER)
 #endif
@@ -98,8 +102,6 @@ int cgc_fdwait(int nfds, cgc_fd_set *readfds, cgc_fd_set *writefds,
 int allocate(cgc_size_t length, int is_X, void **addr);
 int deallocate(void *addr, cgc_size_t length);
 int cgc_random(void *buf, cgc_size_t count, cgc_size_t *rnd_bytes);
-
-void *cgc_initialize_secret_page(void);
 
 // All of the following functions are defined in asm (maths.S)
 // The asm symbols are being forced to match maths.S keep compatibility across OS's

--- a/tools/manual_patches.yaml
+++ b/tools/manual_patches.yaml
@@ -24,21 +24,13 @@ all:
   re:
     '([^s])size_t': '\1cgc_size_t'
 
-    # Fix mains to include a call to cgc_initialize_secret_page
-    # This *should* cover all of them
-
     # Get rid of fastcall on main
     '__attribute__\(\(fastcall\)\)\s+main': 'main'
 
-    # Fix for no argument main
-    'main\s*\(\s*(void)?\s*\)\s*\{': |
-        main() {
-            cgc_initialize_secret_page();
-
-    # Fix for main that expects the secret page addr as the first argument
+    # Fix for main that expects the flag page addr as the first argument
     'main\s*\(\s*int\s+([^\,]+)\,([^\)]+)\s*\)\s*\{': |
         main(int \1, \2) {
-            \1 = (int) cgc_initialize_secret_page();
+            \1 = CGC_FLAG_PAGE_ADDRESS;
 
 
 # Some fixes for challenges that used C++


### PR DESCRIPTION
This ensures that the secret page is initialized before `main` starts,
and requires less patching of the CBs. As an additional advantage, the
CBs now play nicer with tools such as AFL.