### PR TITLE
Win build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ function(build path target)
                           RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_CURRENT_BINARY_DIR})
 
     # Add patched defines
-    target_compile_definitions(${target}_patched PUBLIC "${patch_defs}")
+    target_compile_definitions(${target}_patched PUBLIC ${patch_defs})
 
     target_link_libraries(${target} LINK_PUBLIC cgc)
     target_link_libraries(${target}_patched LINK_PUBLIC cgc)
@@ -147,10 +147,10 @@ endfunction(buildPOV)
 
 function(buildCB)
     # Generate all the patched #defines for this challenge
-    set(patch_defs "-DPATCHED")
+    set(patch_defs -DPATCHED)
     if(VULN_COUNT)
         foreach(i RANGE 1 ${VULN_COUNT})
-            set(patch_defs "${patch_defs} -DPATCHED_${i}")
+            set(patch_defs ${patch_defs} -DPATCHED_${i})
         endforeach()
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,12 @@ if(WIN32)
     add_compile_options(
         /w
         /W0
-        /Zi
+        /Z7
+        /GS-
+        /GR-
+        /guard:cf-
     )
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /MACHINE:X86")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /MACHINE:X86 /NXCOMPAT:NO /SAFESEH:NO /DYNAMICBASE:NO")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /MACHINE:X86")
 
     # Read in challenges to exclude from build


### PR DESCRIPTION
A couple of CMake changes to get things building correctly on windows

* disables features like cookies, NX, ASLR, expections
* Some of the patched challenges were being build wrong due to CMake passing the `-DPATCHED_#` defines incorrectly, this fixes the issue