### PR TITLE
build: Expose CMAKE_OPTS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ mkdir -p ${DIR}/build
 cd ${DIR}/build
 
 echo "Creating Makefiles"
-CMAKE_OPTS="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+CMAKE_OPTS="${CMAKE_OPTS} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 
 # Honor CC and CXX environment variables, default to clang otherwise
 CC=${CC:-clang}


### PR DESCRIPTION
Allows users to do something like this:

```bash
CMAKE_OPTS="-DCMAKE_WHATEVER" ./build.sh
```