### PR TITLE
Use -1 as the mmap file descriptor with MAP_ANONYMOUS

### DIFF
--- a/include/libcgc.c
+++ b/include/libcgc.c
@@ -155,7 +155,7 @@ int cgc_allocate(cgc_size_t length, int is_executable, void **addr) {
   if (is_executable)
     page_perms |= PROT_EXEC;
 
-  void *return_address = mmap(NULL, length, page_perms, MAP_ANONYMOUS | MAP_PRIVATE, 0, 0);
+  void *return_address = mmap(NULL, length, page_perms, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
 
   if (return_address == MAP_FAILED) {
     return errno;


### PR DESCRIPTION
Linux simply ignores the fd argument with MAP_ANONYMOUS, but some
other systems (I checked the FreeBSD man page) require that the
placeholder value be -1. Logically this makes sense because -1
is never a valid file descriptor, whereas 0 is the file descriptor
for standard input.