### PR TITLE
Add -fcommon to prevent multiple definitions build error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ else(WIN32)
     # Default flags for everything
     add_compile_options(
         -fno-builtin
+        -fcommon
         -w
         -g3
         -m32


### PR DESCRIPTION
This happens on newer compiler versions beginning at GCC 10 and Clang 11

closes #81 