### PR TITLE
CMakeLists.txt: Fix incorrect _FORTIFY_SOURCE macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,7 @@ endif()
 
 add_definitions(
     -Derrno=__cgc_errno
-    -DFORTIFY_SOURCE=0
+    -D_FORTIFY_SOURCE=0
 )
 
 if(LINUX)


### PR DESCRIPTION
The fortify source mitigation is set by the _FORTIFY_SOURCE macro set along with the same optimization level. We used a `-DFORTIFY_SOURCE=0` which is invalid and should be `-D_FORTIFY_SOURCE=0` instead.

To be honest, we could even remove this flag as well, but I think it is fine to leave it, but it should be spelled correctly then :).